### PR TITLE
Fix types exposure

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,90 +1,91 @@
-declare namespace Riot {
+declare namespace riot {
+  var version: string;
+  var vdom: Tag.Instance[];
+  var settings: { brackets: string };
+  var util: { tmpl: { errorHandler: (err: Error) => void } };
 
-  class Instance {
+  /**
+   * @browser
+   * @server
+   */
+  function mount(tagName: string | '*', opts?: any): Tag.Instance[];
+  function mount(tagSelector: string, tagName: string, opts?: any): Tag.Instance[];
+  function mount(domNode: Element, tagName: string, opts?: any): Tag.Instance[];
 
-    version: string;
-    vdom: Tag.Instance[];
-    settings: { brackets: string };
-    util: { tmpl: { errorHandler: (err: Error) => void } };
+  /**
+   * @server
+   */
+  function render(tagName: string, opts?: any): string;
 
-    /**
-     * @browser
-     * @server
-     */
-    mount(tagName: string | '*', opts?: any): Tag.Instance[];
-    mount(tagSelector: string, tagName: string, opts?: any): Tag.Instance[];
-    mount(domNode: Element, tagName: string, opts?: any): Tag.Instance[];
+  /**
+   * @browser
+   */
+  function update(): Tag.Instance[];
 
-    /**
-     * @server
-     */
-    render(tagName: string, opts?: any): string;
+  /**
+   * @browser
+   * @server
+   */
+  function tag(tagName: string, html: string, construct?: (opts: any) => void): Tag;
+  function tag(tagName: string, html: string, css: string, construct?: (opts: any) => void): Tag;
+  function tag(tagName: string, html: string, css: string, attrs: string, construct?: (opts: any) => void): Tag;
 
-    /**
-     * @browser
-     */
-    update(): Tag.Instance[];
-
-    /**
-     * @browser
-     * @server
-     */
-    tag(tagName: string, html: string, construct?: (opts: any) => void): Tag.Tag;
-    tag(tagName: string, html: string, css: string, construct?: (opts: any) => void): Tag.Tag;
-    tag(tagName: string, html: string, css: string, attrs: string, construct?: (opts: any) => void): Tag.Tag;
-
-    /**
-     * @browser
-     * @server
-     */
-    Tag(impl: Tag.Impl, conf: Tag.Config, innerHTML: string): Tag.Tag;
-
-    /**
-     * @browser
-     */
-    compile(callback: () => void): void;
-    compile(url: string, callback: () => void): void;
-    compile(tagHtml: string, returnString?: boolean): void | string;
-
-    /**
-     * @browser
-     * @server
-     */
-    observable<T>(element: T): T & Observable;
-
-    /**
-     * @browser
-     * @server
-     */
-    route: Router.Router;
-
-    /**
-     * @server
-     */
-    parsers: {
-      css: {
-        less: Parser.Css,
-        sass: Parser.Css,
-        scss: Parser.Css,
-        stylus: Parser.Css
-      } & any,
-      js: {
-        none: Parser.Javascript,
-        javascript: Parser.Javascript,
-        typescript: Parser.Javascript,
-        es6: Parser.Javascript,
-        babel: Parser.Javascript,
-        coffee: Parser.Javascript,
-        coffeescript: Parser.Javascript
-      } & any,
-      html: {
-        jade: Parser.Html,
-        pug: Parser.Html
-      } & any
-    };
+  /**
+   * @browser
+   * @server
+   */
+  class Tag {
+    constructor(impl: Tag.Impl, conf: Tag.Config, innerHTML: string);
+    impl: Tag.Impl;
+    conf: Tag.Config;
+    innerHTML: string;
   }
 
-  export interface Observable {
+  /**
+   * @browser
+   */
+  function compile(callback: () => void): void;
+  function compile(url: string, callback: () => void): void;
+  function compile(tagHtml: string, returnString?: boolean): void | string;
+
+  /**
+   * @browser
+   * @server
+   */
+  function observable<T>(element: T): T & Observable;
+
+  /**
+   * @browser
+   * @server
+   */
+  var route: Router;
+
+  /**
+   * @server
+   */
+  var parsers: {
+    css: {
+      less: Parser.Css,
+      sass: Parser.Css,
+      scss: Parser.Css,
+      stylus: Parser.Css
+    } & any,
+    js: {
+      none: Parser.Javascript,
+      javascript: Parser.Javascript,
+      typescript: Parser.Javascript,
+      es6: Parser.Javascript,
+      babel: Parser.Javascript,
+      coffee: Parser.Javascript,
+      coffeescript: Parser.Javascript
+    } & any,
+    html: {
+      jade: Parser.Html,
+      pug: Parser.Html
+    } & any
+  };
+
+  interface Observable {
     on<T>(events: string | '*', callback: (event?: string, ...args: any[]) => void): T;
     one<T>(event: string, callback: () => void): T;
     off<T>(events: string | '*', callbackToRemove?: () => void): T;
@@ -92,22 +93,17 @@ declare namespace Riot {
   }
 
   namespace Tag {
-    class Impl {
+    interface Impl {
       impl: string;
       attrs: any;
       fn(opts?: any): void;
     }
-    class Config {
+    interface Config {
       isLoop: boolean;
       hasImpl: boolean;
       opts: any;
       item: any;
       root: Node;
-    }
-    class Tag {
-      impl: Impl;
-      conf: Config;
-      innerHTML: string;
     }
     interface Instance extends Observable {
       opts: any;
@@ -133,18 +129,17 @@ declare namespace Riot {
     interface Route { (callback: () => void): void; }
     interface FilterRoute { (filter: string, callback: (...params: any[]) => void): void; }
     interface RouteTo { (filter: string, title?: string, replaceHistory?: boolean): void; }
-    type Router = Route | FilterRoute | RouteTo | {
-      create(): Router;
-      start(autoExec?: boolean): void;
-      stop(): void;
-      exec(callback?: () => void): void;
-      query(): string;
-      base(path: string): void;
-      parser(parser: (path: string) => string, secondParser?: (path: string, filter: string) => string): void;
-    };
   }
-}
 
-declare var riot: Riot.Instance;
+  type Router = Router.Route | Router.FilterRoute | Router.RouteTo | {
+    create(): Router;
+    start(autoExec?: boolean): void;
+    stop(): void;
+    exec(callback?: () => void): void;
+    query(): string;
+    base(path: string): void;
+    parser(parser: (path: string) => string, secondParser?: (path: string, filter: string) => string): void;
+  };
+}
 
 export = riot;

--- a/test/test.ts
+++ b/test/test.ts
@@ -2,6 +2,9 @@ import test = require('blue-tape');
 import riot = require('riot');
 
 test('riot exists', (t) => {
-  t.plan(1);
+  t.plan(2);
   t.notEqual(riot, undefined);
+  let emitter: riot.Observable = riot.observable('');
+
+  t.notEqual(emitter, undefined);
 });


### PR DESCRIPTION
I think the `riot` should not be a class, and `riot.Tag` is a class.

I'm not familiar with `riot`, so you can double check.
