### PR TITLE
riot.route.create() error TS2339: Property 'create' does not exist on type 'Route | FilterRoute ...

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -142,7 +142,7 @@ declare namespace riot {
     interface RouteTo { (filter: string, title?: string, replaceHistory?: boolean): void; }
   }
 
-  type Router = Router.Route | Router.FilterRoute | Router.RouteTo | {
+  interface Router extends Router.Route, Router.FilterRoute, Router.RouteTo {
     create(): Router;
     start(autoExec?: boolean): void;
     stop(): void;
@@ -150,7 +150,7 @@ declare namespace riot {
     query(): string;
     base(path: string): void;
     parser(parser: (path: string) => string, secondParser?: (path: string, filter: string) => string): void;
-  };
+  }
 }
 
 export = riot;


### PR DESCRIPTION
The code below, when compiled, gives the following error:

> index.ts(2,12): error TS2339: Property 'start' does not exist on type 'Route | FilterRoute | RouteTo | { create(): Route | FilterRoute | RouteTo | any; start(autoExec?:...'. 

``` javascript
import riot = require('riot');
riot.route.start();
```

tsconfig.json

``` javascript
{
    "compilerOptions": {
        "outDir": "build",
        "module": "commonjs",
        "moduleResolution": "node"
    },
    "exclude": [
        "node_modules",
    ]
}
```

I think, the reason for this error is this particular line containing union types:

``` javascript
 type Router = Router.Route | Router.FilterRoute | Router.RouteTo | {
```

I recommend using this instead - as it has solved the problem for me:

``` javascript
  interface Router extends Router.Route , Router.FilterRoute , Router.RouteTo  {
```
